### PR TITLE
FIX: src/logika/zadani/2-3-02.tex

### DIFF
--- a/src/logika/zadani/2-3-02.tex
+++ b/src/logika/zadani/2-3-02.tex
@@ -4,7 +4,7 @@ funkčním symbolem f.
 \begin{enumerate}
   \item Najděte nějakou realizaci jazyka L na množině $\left \{ 1,2,3 \right
   \}$.
-  \item Nechť $\varphi$ je následující formule jazyka L: $\forall z \forall y
+  \item Nechť $\varphi$ je následující formule jazyka L: $\forall x \forall y
   \exists z p(f(x,z),y)$
 \end{enumerate}
 


### PR DESCRIPTION
`∀z ∀y ∃z p(f (x, z), y)` fixed to `∀x ∀y ∃z p(f (x, z), y)`

![image](https://user-images.githubusercontent.com/22373707/47952817-9348f580-df75-11e8-9f74-3d51a73eff85.png)


